### PR TITLE
Support enterprise bluejeans accounts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,12 @@
         "https://*.zoom.us/j/*",
         "https://zoom.us/s/*",
         "https://*.zoom.us/s/*",
-        "https://bluejeans.com/*"
+        "https://bluejeans.com/*",
+        "https://*.bluejeans.com/*"
+      ],
+      "exclude_matches": [
+        "https://www.bluejeans.com/*",
+        "https://slack-api.bluejeans.com/*"
       ],
       "js": [
         "content.js"


### PR DESCRIPTION
Enterprise bluejeans accounts can have a subdomain (eg: google.bluejeans.com/<meeting_id>)
Changes:
Added enterprise domains to the matched domains of bluejeans.

Exceptions:
- www.bluejeans.com - the main site
- slack-api.bluejeans.com - used to setup the bluejeans app in slack 